### PR TITLE
Add environment.yml to fix Python CI

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,5 @@
+name: base
+channels:
+  - defaults
+dependencies:
+  - python=3.10


### PR DESCRIPTION
The conda workflow was failing immediately because environment.yml was missing. All Python scripts use only stdlib modules, so this file just pins Python 3.10 as required by the workflow.

https://claude.ai/code/session_0177hkFifL4dYH1FaxhFUoE5